### PR TITLE
Support non-master PR base branch

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -23,7 +23,8 @@ def clone (repo_url, git_ref = "master") {
 
 /**
     Function to checkout upstream that has triggerred current
-    pipeline, for example PR branch.
+    pipeline, for example PR branch. For PRs this will already merge
+    with the base branch.
 
     Requires administrator approval for allow access to:
 
@@ -97,7 +98,7 @@ def mapSteps (names, action) {
 *******************************************************************************/
 
 def getSources (name) {
-    def git_ref = 'master'
+    def base_branch = 'master'
     def pr_repo
     def pr_id
 
@@ -115,7 +116,7 @@ def getSources (name) {
     if (pr_repo && pr_id) {
         def api_url = "https://api.github.com/repos/dlang/$pr_repo/pulls/$pr_id"
         def extract_cmd = "jq -r '.base.ref'"
-        git_ref = sh(
+        base_branch = sh(
             script: "curl -s '$api_url' | $extract_cmd",
             returnStdout: true
         ).trim();
@@ -125,7 +126,7 @@ def getSources (name) {
         cloneUpstream()
     }
     else {
-        clone("https://github.com/dlang/${name}.git", git_ref)
+        clone("https://github.com/dlang/${name}.git", base_branch)
     }
 }
 

--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -97,19 +97,35 @@ def mapSteps (names, action) {
 *******************************************************************************/
 
 def getSources (name) {
+    def git_ref = 'master'
+    def pr_repo
+    def pr_id
+
     // presence of CHANGE_URL environment variable means this pipeline tests
     // Pull Request and has to checkout PR branch instead of master branch
     // for relevant repository:
     def regex = /https:\/\/github.com\/[^\/]+\/([^\/]+)\/pull\/(\d+)/
     def match = (env.CHANGE_URL =~ regex)
-    def pr_repo = match ? match[0][1] : ""
+    if (match) {
+        pr_repo = match[0][1]
+        pr_id = match[0][2]
+    }
     match = null
+
+    if (pr_repo && pr_id) {
+        def api_url = "https://api.github.com/repos/dlang/$pr_repo/pulls/$pr_id"
+        def extract_cmd = "jq -r '.base.ref'"
+        git_ref = sh(
+            script: "curl -s '$api_url' | $extract_cmd",
+            returnStdout: true
+        ).trim();
+    }
 
     if (pr_repo == name) {
         cloneUpstream()
     }
     else {
-        clone("https://github.com/dlang/${name}.git")
+        clone("https://github.com/dlang/${name}.git", git_ref)
     }
 }
 


### PR DESCRIPTION
Example: https://ci2.dawg.eu/blue/organizations/jenkins/dlang-test-organization%2Fdmd/detail/PR-1/32/pipeline/28

Not very elegant but I don't think base branch info can be retrieved via Jenkins own metadata