### PR TITLE
Github Organization/Branch Sources plugin creates unique workspaces per job (PR/branch)

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -179,6 +179,12 @@ def testDownstreamProject (name) {
 *******************************************************************************/
 
 node { // for now whole pipeline runs on one node because no slaves are present
+    /* Use the same workspace, no matter what job (dmd, druntime,...)  triggered
+     * the build.  The workspace step will take care of concurrent test-runs and
+     * allocate additional workspaces if necessary.  This setup avoids to
+     * reclone repos for each test-run.
+     */
+    ws: 'dlangci'
 
     def projects = [ 'dmd', 'druntime', 'phobos', 'dub', 'tools' ]
 


### PR DESCRIPTION
This goes somewhat against our idea to cache the checkouts.
It seems the impedance mismatch originates from us wanting to run the same testsuite for multiple repositories.