### PR TITLE
drop compiler tests

### DIFF
--- a/pipeline.groovy
+++ b/pipeline.groovy
@@ -247,13 +247,6 @@ node { ws(dir: 'dlang_ci') {
         dir('phobos',   action)
     }
 
-    stage ('Test Compiler') {
-        parallel mapSteps(
-            [ 'dmd', 'druntime', 'phobos' ],
-            { name -> sh "make -f posix.mak auto-tester-test MODEL=64 --jobs=4" }
-        )
-    }
-
     stage ('Build Tools') {
         def repos = [
             'dub': {


### PR DESCRIPTION
- redundant with auto-tester
- take half of the test time
- should run concurrently to project tests (maybe on a separate node)