### PR TITLE
fix stale hostname in shutdown check

### DIFF
--- a/ansible/roles/buildkite_agent/files/agent-shutdown-check.service
+++ b/ansible/roles/buildkite_agent/files/agent-shutdown-check.service
@@ -1,12 +1,11 @@
 [Unit]
 Description=Check whether server can be decomissioned
-# for correct hostname in %H
-After=cloud-init.target
 
 [Service]
 Type=simple
 EnvironmentFile=/etc/dlang-bot-agent-token.conf
-ExecStart=/usr/bin/curl -fsS -H 'Authentication: Bearer ${DLANG_BOT_AGENT_TOKEN}' https://dlang-bot.herokuapp.com/agent_shutdown_check -d 'hostname=%H'
+ExecStartPre=/bin/sh -c '/bin/systemctl set-environment HOSTNAME=$(hostname)'
+ExecStart=/usr/bin/curl -fsS -H 'Authentication: Bearer ${DLANG_BOT_AGENT_TOKEN}' https://dlang-bot.herokuapp.com/agent_shutdown_check -d 'hostname=${HOSTNAME}'
 Restart=on-failure
 RestartSec=10
 # retry up to 3 times

--- a/ansible/roles/buildkite_agent/files/agent-shutdown-check.timer
+++ b/ansible/roles/buildkite_agent/files/agent-shutdown-check.timer
@@ -1,7 +1,5 @@
 [Unit]
 Description=Check whether server can be decomissioned every hour
-# for correct hostname in %H
-After=cloud-init.target
 
 [Timer]
 OnBootSec=54min


### PR DESCRIPTION
- systemd unit would sometimes be loaded before the real hostname is
  applied, thus preventing shutdown of that server