### PR TITLE
buildkite/build_project.sh: Use --debug=ae_unittest with ae

### DIFF
--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -251,7 +251,7 @@ case "$REPO_FULL_NAME" in
     CyberShadow/ae)
         # remove failing extended attribute test
         perl -0777 -pi -e "s/unittest[^{]*{[^{}]*xAttrs[^{}]*}//" sys/file.d
-        use_travis_test_script
+        dub test "--compiler=$DC" --debug=ae_unittest
         ;;
 
     ikod/dlang-requests)


### PR DESCRIPTION
Fixes https://github.com/CyberShadow/ae/issues/58

Expected to fail until the Druntime regression is addressed somehow.