### PR TITLE
Remove sociomantic-tsunami/swarm from buildkite

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -129,7 +129,7 @@ projects=(
     "dlang/phobos" # 4m50s
     "dlang/phobos+no-autodecode"
     "sociomantic-tsunami/ocean" # 4m49s
-    "sociomantic-tsunami/swarm"
+    #"sociomantic-tsunami/swarm"
     "sociomantic-tsunami/turtle"
     "dlang/dub" # 3m55s
     "vibe-d/vibe-core+epoll" # 3m38s


### PR DESCRIPTION
https://github.com/sociomantic-tsunami/swarm/commit/d7b45d7b03890d7dc1c342d0ae196e808c6e028c is not correct fix and Phobos CI still fails, so temporary disable.

cc @thewilsonator 