### PR TITLE
Add `dlang/dub-registry` to *Buildkite* tests

### DIFF
--- a/buildkite.sh
+++ b/buildkite.sh
@@ -171,6 +171,7 @@ projects=(
     "DerelictOrg/DerelictSDL2"
     "dlang-community/containers"
     "dlang/undeaD"
+    "dlang/dub-registry"
     "DlangScience/scid"
     "ikod/dlang-requests"
     "symmetryinvestments/autowrap"

--- a/buildkite/build_project.sh
+++ b/buildkite/build_project.sh
@@ -40,6 +40,9 @@ case "$REPO_URL" in
     https://github.com/sociomantic-tsunami/turtle)
         ref_to_use=v11.x.x
         ;;
+    https://github.com/dlang/dub-registry)
+        ref_to_use=master
+        ;;
     https://github.com/dlang/undeaD)
         ref_to_use=master
         ;;


### PR DESCRIPTION
Add `dlang/dub-registry` to *Buildkite* tests.

#### Rationale

It’s part of our GitHub org, so we can fix it in case of breaking changes ourselves if needed.
It could have caught <https://github.com/dlang/dmd/issues/23642>.